### PR TITLE
Fix compilation issues for non-ESP32 MCUs and add RP2040 support

### DIFF
--- a/Display_cfg.h
+++ b/Display_cfg.h
@@ -23,11 +23,15 @@
 #define DISPLAY_WIDTH   400         // Display width in pixel
 #define DISPLAY_HEIGHT  240         // Display height in pixel
 
+#define USE_ESP32_DMA  // 使用ESP32 DMA
+#define DIFF_LINE_UPDATE   // 差异行更新
+
 //=================================================================
 // Wiring details: https://github.com/Gbertaz/JDI_MIP_Display#wiring
 //=================================================================
 
-#define SPI_FREQUENCY   4000000
+#define SPI_FREQUENCY   4000000     // SPI frequency in Hz
+#define SPI_CHANNEL     spi0        // SPI channel number
 #define PIN_MISO        D9          // SPI Data Signal pin
 #define PIN_MOSI        D10         // SPI Data Signal pin
 #define PIN_SCK         D8          // SPI Clock Signal pin

--- a/Display_cfg.h
+++ b/Display_cfg.h
@@ -27,24 +27,10 @@
 // Wiring details: https://github.com/Gbertaz/JDI_MIP_Display#wiring
 //=================================================================
 
-//===============================
-// Wiring example Teensy 4.1
-#define PIN_SCS         10          // SPI Chip Select Signal pin
-#define PIN_DISP        22          // Display ON/OFF Switching Signal pin
-#define PIN_FRONTLIGHT  23          // Frontlight pin. Optional depending on the display model
-
-//===============================
-// Wiring example Esp8266 Wemos D1 mini
-/*
-#define PIN_SCS         15         // D8 GPIO15 SPI Chip Select Signal pin
-#define PIN_DISP        4          // D2 GPIO4  Display ON/OFF Switching Signal pin
-#define PIN_FRONTLIGHT  5          // D1 GPIO5  Frontlight pin. Optional depending on the display model
-*/
-
-//===============================
-// Wiring example Esp32 NodeMCU
-/*
-#define PIN_SCS         5          // GPIO5     SPI Chip Select Signal pin
-#define PIN_DISP        21         // GPIO21    Display ON/OFF Switching Signal pin
-#define PIN_FRONTLIGHT  22         // GPIO22    Frontlight pin. Optional depending on the display model
-*/
+#define SPI_FREQUENCY   4000000
+#define PIN_MISO        D9          // SPI Data Signal pin
+#define PIN_MOSI        D10         // SPI Data Signal pin
+#define PIN_SCK         D8          // SPI Clock Signal pin
+#define PIN_SCS         D7          // SPI Chip Select Signal pin
+#define PIN_DISP        D0          // Display ON/OFF Switching Signal pin
+#define PIN_FRONTLIGHT  -1          // Frontlight pin. Optional depending on the display model

--- a/JDI_MIP_Display.h
+++ b/JDI_MIP_Display.h
@@ -29,7 +29,7 @@
 #include <Adafruit_GFX.h>
 #include <Display_cfg.h>
 
-
+#define USE_ESP32_DMA  // 使用ESP32 DMA
 #define DIFF_LINE_UPDATE   // 差异行更新
 #define HALF_WIDTH (DISPLAY_WIDTH / 2)
 
@@ -54,7 +54,7 @@ class JDI_MIP_Display : public Adafruit_GFX
 {
 public:
         JDI_MIP_Display();
-        void begin(int sck = -1, int miso = -1, int mosi = -1, int ss = -1, int fre = -1, bool dmaEN = 0);
+        void begin();
         void refresh();
         void refresh2();
         void displayOn();
@@ -62,14 +62,22 @@ public:
         void clearScreen();
         void frontlightOn();
         void frontlightOff();
+        void selectSPI(SPIClass& spi, SPISettings spi_settings);
         void setBackgroundColor(uint16_t color);
         void drawBufferedPixel(int16_t x, int16_t y, uint16_t color);
         void pushPixelsDMA(uint8_t *image, uint32_t len);
 private:
+        uint8_t _sck;         // 时钟信号 Clock signal
+        uint8_t _miso;        // 主输入从输出 Master input from output
+        uint8_t _mosi;        // 主输出从输入 Master output from input
         uint8_t _scs;         // 芯片选择信号 Chip selection signal
         uint8_t _disp;        // 显示ON/OFF开关信号 Display ON/OFF switch signal
         uint8_t _frontlight;  // 前置灯 Front lights
         uint16_t _background; // 背景 background
+        uint32_t _freq;       // SPI频率 SPI frequency
+
+        SPIClass* _pSPIx;
+        SPISettings _spi_settings;
 
         char _backBuffer[(DISPLAY_WIDTH / 2) * DISPLAY_HEIGHT];
 #ifdef DIFF_LINE_UPDATE
@@ -78,7 +86,7 @@ private:
         void sendLineCommand(char *line_cmd, int line);
         void drawPixel(int16_t x, int16_t y, uint16_t color);
         bool compareBuffersLine(int lineIndex);
-
+#ifdef USE_ESP32_DMA
         // 检查DMA是否已完成-使用while（tft.dmaBusy）；等待阻塞
         // Check if DMA has been completed - use while (tft. dmaBusy); Waiting for blocking
         bool DMA_Enabled = false; // DMA启用状态的标志 Flag for DMA enabled status
@@ -88,5 +96,6 @@ private:
         void _pushPixelsDMA(uint8_t *image, uint32_t len);
         bool initDMA(int sck, int miso, int mosi, int ss, int fre);
         void deInitDMA(void);
+#endif
 };
 #endif

--- a/JDI_MIP_Display.h
+++ b/JDI_MIP_Display.h
@@ -29,8 +29,6 @@
 #include <Adafruit_GFX.h>
 #include <Display_cfg.h>
 
-#define USE_ESP32_DMA  // 使用ESP32 DMA
-#define DIFF_LINE_UPDATE   // 差异行更新
 #define HALF_WIDTH (DISPLAY_WIDTH / 2)
 
 #define COLOR_BLACK 0x00

--- a/examples/EfficientUpdate_test/EfficientUpdate_test.ino
+++ b/examples/EfficientUpdate_test/EfficientUpdate_test.ino
@@ -84,7 +84,7 @@ unsigned int frames = 0;
 unsigned long lastFpsMillis = 0;
 
 // uncomment the following 2 lines if you want to use a custom SPI bus, for example spi0 on the RP2040
-// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ spi0,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
+// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ SPI_CHANNEL,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
 
 void setup() {
   // jdi_display.selectSPI(SPIn, SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));

--- a/examples/EfficientUpdate_test/EfficientUpdate_test.ino
+++ b/examples/EfficientUpdate_test/EfficientUpdate_test.ino
@@ -83,7 +83,11 @@ int fps = 0;
 unsigned int frames = 0;
 unsigned long lastFpsMillis = 0;
 
+// uncomment the following 2 lines if you want to use a custom SPI bus, for example spi0 on the RP2040
+// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ spi0,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
+
 void setup() {
+  // jdi_display.selectSPI(SPIn, SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   jdi_display.begin();
   delay(50);
   jdi_display.displayOn();

--- a/examples/FPS_test/FPS_test.ino
+++ b/examples/FPS_test/FPS_test.ino
@@ -84,7 +84,11 @@ int fps = 0;
 unsigned int frames = 0;
 unsigned long startMillis = 0;
 
+// uncomment the following 2 lines if you want to use a custom SPI bus, for example spi0 on the RP2040
+// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ spi0,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
+
 void setup() {
+  // jdi_display.selectSPI(SPIn, SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));
   jdi_display.begin();
   delay(50);
   jdi_display.displayOn();

--- a/examples/FPS_test/FPS_test.ino
+++ b/examples/FPS_test/FPS_test.ino
@@ -85,7 +85,7 @@ unsigned int frames = 0;
 unsigned long startMillis = 0;
 
 // uncomment the following 2 lines if you want to use a custom SPI bus, for example spi0 on the RP2040
-// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ spi0,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
+// SPIClassRP2040 SPIn(/*spi_inst_t *spi*/ SPI_CHANNEL,  /*pin_size_t rx*/ PIN_MISO, /*pin_size_t cs*/ PIN_SCS, /*pin_size_t sck*/ PIN_SCK, /*pin_size_t tx*/ PIN_MOSI);
 
 void setup() {
   // jdi_display.selectSPI(SPIn, SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));


### PR DESCRIPTION
- Resolve compilation errors on MCUs other than ESP32 series
- Introduce USE_ESP32_DMA define to toggle ESP32 DMA usage
- Fix compatibility issues with RP2040
- Add selectSPI function to support SPI channel selection
- Implement spi.beginTransaction and spi.endTransaction where necessary to improve robustness