### PR TITLE
[验证成功] 增加屏幕旋转功能，适配老王144x72_JDI_Memory LCD屏幕，增加屏幕旋转测试例子

### DIFF
--- a/Display_cfg.h
+++ b/Display_cfg.h
@@ -20,21 +20,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#define DISPLAY_WIDTH   400         // Display width in pixel
-#define DISPLAY_HEIGHT  240         // Display height in pixel
+// #define DISPLAY_WIDTH   400         // Display width in pixel
+// #define DISPLAY_HEIGHT  240         // Display height in pixel
 
-#define USE_ESP32_DMA  // 使用ESP32 DMA
-#define DIFF_LINE_UPDATE   // 差异行更新
+//#define USE_ESP32_DMA  // 使用ESP32 DMA
+//#define DIFF_LINE_UPDATE   // 差异行更新
 
 //=================================================================
 // Wiring details: https://github.com/Gbertaz/JDI_MIP_Display#wiring
 //=================================================================
 
+// #define SPI_FREQUENCY   4000000     // SPI frequency in Hz
+// #define SPI_CHANNEL     spi0        // SPI channel number
+// #define PIN_MISO        D9          // SPI Data Signal pin
+// #define PIN_MOSI        D10         // SPI Data Signal pin
+// #define PIN_SCK         D8          // SPI Clock Signal pin
+// #define PIN_SCS         D7          // SPI Chip Select Signal pin
+// #define PIN_DISP        D0          // Display ON/OFF Switching Signal pin
+// #define PIN_FRONTLIGHT  -1          // Frontlight pin. Optional depending on the display model
+
+//=================================================================
+// 适配老王JDI_Memory LCD屏幕，采用MEGA2560进行驱动
+// 分辨率为：144x72
+//=================================================================
+
+#define USE_144_72_LCD
+
+#define DISPLAY_WIDTH   144         // Display width in pixel
+#define DISPLAY_HEIGHT  72         // Display height in pixel
+
+//控制引脚
+#define PIN_SCS         A0          // SPI Chip Select Signal pin
+#define PIN_DISP        A1          // Display ON/OFF Switching Signal pin
+
+//SPI设置，不用关注
 #define SPI_FREQUENCY   4000000     // SPI frequency in Hz
 #define SPI_CHANNEL     spi0        // SPI channel number
-#define PIN_MISO        D9          // SPI Data Signal pin
-#define PIN_MOSI        D10         // SPI Data Signal pin
-#define PIN_SCK         D8          // SPI Clock Signal pin
-#define PIN_SCS         D7          // SPI Chip Select Signal pin
-#define PIN_DISP        D0          // Display ON/OFF Switching Signal pin
+#define PIN_MISO        50          // SPI Data Signal pin
+#define PIN_MOSI        51          // SPI Data Signal pin
+#define PIN_SCK         52          // SPI Clock Signal pin
 #define PIN_FRONTLIGHT  -1          // Frontlight pin. Optional depending on the display model

--- a/JDI_MIP_Display.h
+++ b/JDI_MIP_Display.h
@@ -51,7 +51,7 @@
 class JDI_MIP_Display : public Adafruit_GFX
 {
 public:
-        JDI_MIP_Display();
+        JDI_MIP_Display(uint8_t rot = 1);
         void begin();
         void refresh();
         void refresh2();
@@ -64,6 +64,7 @@ public:
         void setBackgroundColor(uint16_t color);
         void drawBufferedPixel(int16_t x, int16_t y, uint16_t color);
         void pushPixelsDMA(uint8_t *image, uint32_t len);
+        void set_direction(uint16_t n);
 private:
         uint8_t _sck;         // 时钟信号 Clock signal
         uint8_t _miso;        // 主输入从输出 Master input from output
@@ -73,6 +74,7 @@ private:
         uint8_t _frontlight;  // 前置灯 Front lights
         uint16_t _background; // 背景 background
         uint32_t _freq;       // SPI频率 SPI frequency
+        uint16_t _rotation;    // 屏幕旋转方向 0 90 180 270
 
         SPIClass* _pSPIx;
         SPISettings _spi_settings;

--- a/JDI_MIP_Display.h
+++ b/JDI_MIP_Display.h
@@ -51,7 +51,7 @@
 class JDI_MIP_Display : public Adafruit_GFX
 {
 public:
-        JDI_MIP_Display(uint8_t rot = 1);
+        JDI_MIP_Display(uint16_t rot = 1);
         void begin();
         void refresh();
         void refresh2();

--- a/examples/FPS_and_Rotation_144x72/FPS_and_Rotation_144x72.ino
+++ b/examples/FPS_and_Rotation_144x72/FPS_and_Rotation_144x72.ino
@@ -1,0 +1,157 @@
+//======================================================================
+//======================================================================
+//
+//  这个例子基于FPS_test，增加了屏幕旋转测试，对144x72分辨率的屏幕显示做了优化
+//
+//
+//  接线：            MEGA2560
+//       PIN_SCS         A0         
+//       PIN_DISP        A1  
+//       PIN_MOSI        51         
+//       PIN_SCK         52        
+//
+//  使用前请注意:
+//     1) 打开 Display_cfg.h 文件
+//     2) 使能 #define USE_144_72_LCD
+//     3) 配置 PIN_DISP 和 PIN_SCS 引脚
+//
+//  License:
+//
+// MIT License
+//
+// Copyright(c) 2021 Giovanni Bertazzoni <nottheworstdev@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//======================================================================
+//======================================================================
+
+#include <JDI_MIP_Display.h>
+
+#define NUMBER_COLORS 8
+
+const uint16_t colors[NUMBER_COLORS] = {COLOR_BLACK,  COLOR_BLUE, COLOR_GREEN,
+                                        COLOR_CYAN,   COLOR_RED,  COLOR_MAGENTA,
+                                        COLOR_YELLOW, COLOR_WHITE};
+
+JDI_MIP_Display jdi_display(0);
+
+int rectHeight = jdi_display.height() / NUMBER_COLORS;
+int rectWidth = jdi_display.width() / 2;
+int startColor = 0;
+int currentColor = 0;
+
+int fps = 0;
+unsigned int frames = 0;
+unsigned long startMillis = 0;
+unsigned long test_rot_Millis = 0;
+uint16_t rot_change_flag = 0;
+
+void setup() {
+    jdi_display.begin();
+    delay(50);
+    jdi_display.displayOn();
+    jdi_display.clearScreen(); // Clear the screen
+    jdi_display.refresh();     // Actually updates the display
+    startMillis = millis();
+    test_rot_Millis = millis();
+}
+
+void loop() {
+
+    //每过一秒使屏幕旋转一次
+    if ((millis() - test_rot_Millis) > 1 * 1000) {
+        test_rot_Millis = millis();
+        if (rot_change_flag==0) {
+            rot_change_flag = 1;
+            jdi_display.set_direction(0);
+            rectHeight = jdi_display.height() / NUMBER_COLORS;
+            rectWidth = jdi_display.width() / 2;
+        } else if (rot_change_flag==1){
+            rot_change_flag = 2;
+            jdi_display.set_direction(90);
+            rectHeight = jdi_display.height() / NUMBER_COLORS;
+            rectWidth = jdi_display.width() / 2;
+        }else if (rot_change_flag==2){
+            rot_change_flag = 3;
+            jdi_display.set_direction(180);
+            rectHeight = jdi_display.height() / NUMBER_COLORS;
+            rectWidth = jdi_display.width() / 2;
+        }else if (rot_change_flag==3){
+            rot_change_flag = 0;
+            jdi_display.set_direction(270);
+            rectHeight = jdi_display.height() / NUMBER_COLORS;
+            rectWidth = jdi_display.width() / 2;
+        }
+    }
+
+    scrollingColors();
+    jdi_display.fillCircle(jdi_display.width() / 2, jdi_display.height() / 2,
+                           20, COLOR_BLUE);
+
+    int xPos = (jdi_display.width() / 2) - 25;
+    int yPos = (jdi_display.height() / 2) - 45;
+
+    jdi_display.setTextColor(COLOR_BLACK, COLOR_WHITE);
+    jdi_display.setTextSize(2);
+    jdi_display.setCursor(xPos, yPos + 10);
+    jdi_display.print("fps");
+
+    if (fps >= 10)
+        xPos -= 20;
+    jdi_display.setTextColor(COLOR_WHITE);
+    jdi_display.setTextSize(2);
+    jdi_display.setCursor(xPos + 20, yPos + 35);
+    jdi_display.print(fps);
+    jdi_display.refresh(); // Actually updates the display
+
+    fps = frames / ((millis() - startMillis) / 1000);
+    frames++;
+}
+
+void scrollingColors() {
+
+    int y = 0;
+
+    currentColor = startColor;
+
+    for (int i = 0; i < NUMBER_COLORS; i++) {
+        jdi_display.fillRect(0, y, rectWidth, rectHeight, colors[currentColor]);
+        y += rectHeight;
+        currentColor++;
+        if (currentColor > NUMBER_COLORS - 1)
+            currentColor %= NUMBER_COLORS;
+    }
+
+    currentColor = startColor;
+    y = jdi_display.height() - rectHeight;
+    for (int i = 0; i < NUMBER_COLORS; i++) {
+        jdi_display.fillRect(rectWidth, y, rectWidth, rectHeight,
+                             colors[currentColor]);
+        y -= rectHeight;
+        currentColor++;
+        if (currentColor > NUMBER_COLORS - 1)
+            currentColor %= NUMBER_COLORS;
+    }
+
+    if (startColor < NUMBER_COLORS - 1)
+        startColor++;
+    else
+        startColor = 0;
+}


### PR DESCRIPTION
[功能更新] ### 增加屏幕旋转功能

- 添加了屏幕旋转功能，适配 JDI 144x72 Memory LCD 显示屏。
- 实现了 set_direction() 方法，用于根据传入参数设置屏幕的旋转方向（0°, 90°, 180°, 270°）。
- 增加了旋转功能的测试用例，确保不同方向的显示正确。

### 测试:

1. 已在硬件上验证各个旋转角度的显示效果，均符合预期。
2. 提供了详细的测试用例，方便后续维护和验证。

### 测试结果：
![Video_20241007_031026_402](https://github.com/user-attachments/assets/0030076b-97c7-44f6-9e40-742407557cd1)


### 感谢:
非常感谢你们为这个项目所做的出色工作！这个项目让我在开发中受益匪浅，希望这次提交的屏幕旋转功能能够进一步增强项目的功能。如果有任何改进建议或反馈，欢迎随时提出！